### PR TITLE
Ensure property tokens don't send back assembly information with generics

### DIFF
--- a/src/FubuLocalization.Tests/PropertyTokenTester.cs
+++ b/src/FubuLocalization.Tests/PropertyTokenTester.cs
@@ -1,6 +1,7 @@
-using System.Globalization;
+using FubuCore.Reflection;
 using FubuTestingSupport;
 using NUnit.Framework;
+using System.Globalization;
 
 namespace FubuLocalization.Tests
 {
@@ -32,9 +33,26 @@ namespace FubuLocalization.Tests
 
             token.FindDefaultHeader(new CultureInfo("en-US")).ShouldBeNull();
         }
+
+        [Test]
+        public void generic_parent_type_is_pretty()
+        {
+            // Ensures we don't have assembly info when using generics.
+            var prop = ReflectionHelper.GetProperty<GenericPropertyTokenTarget<PropertyTokenTarget>>(_ => _.Name);
+            var token = new PropertyToken(prop);
+            token.ParentTypeName.ShouldEqual(prop.DeclaringType.ToString());
+        }
     }
 
     public class PropertyTokenTarget
+    {
+        [HeaderText("The Name"), HeaderText("Different", Culture = "en-CA")]
+        public string Name { get; set; }
+
+        public string NotDecorated { get; set; }
+    }
+
+    public class GenericPropertyTokenTarget<T>
     {
         [HeaderText("The Name"), HeaderText("Different", Culture = "en-CA")]
         public string Name { get; set; }

--- a/src/FubuLocalization/PropertyToken.cs
+++ b/src/FubuLocalization/PropertyToken.cs
@@ -50,7 +50,7 @@ namespace FubuLocalization
             });
 
             ParentType = property.DeclaringType;
-            ParentTypeName = property.DeclaringType.FullName;
+            ParentTypeName = property.DeclaringType.ToString();
             PropertyName = property.Name;
         }
 


### PR DESCRIPTION
Previously the property token's `ParentTypeName` would be:
```
FubuLocalization.Tests.GenericPropertyTokenTarget`1[[FubuLocalization.Tests.PropertyTokenTarget, FubuLocalization.Tests, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]]
```

After this change, it will be:
```
FubuLocalization.Tests.GenericPropertyTokenTarget`1[FubuLocalization.Tests.PropertyTokenTarget]
```